### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "22"
-cache: npm
-script: npm run build
-sudo: false

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ng": "ng",
     "demo": "ng serve ngx-leaflet-draw-demo",
-    "build": "ng build ngx-leaflet-draw --configuration production && node -e \"const fs=require('fs'),p='./dist/ngx-leaflet-draw/index.d.ts';fs.writeFileSync(p,'/// <reference types=\\\"leaflet-draw\\\" />\\n'+fs.readFileSync(p,'utf8'))\" && copyfiles README.md LICENSE CHANGES.md ./dist/ngx-leaflet-draw",
+    "build": "ng build ngx-leaflet-draw --configuration production && node -e \"const fs=require('fs'),d='./dist/ngx-leaflet-draw',p=d+'/'+JSON.parse(fs.readFileSync(d+'/package.json','utf8')).typings;fs.writeFileSync(p,'/// <reference types=\\\"leaflet-draw\\\" />\\n'+fs.readFileSync(p,'utf8'))\" && copyfiles README.md LICENSE CHANGES.md ./dist/ngx-leaflet-draw",
     "watch": "ng build ngx-leaflet-draw --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
## Summary
- Removes the broken `.travis.yml` (Travis stopped working when the repo moved from the `asymmetrik` org to `bluehalo`)
- Adds `.github/workflows/ci.yml` that runs `npm ci` + `npm run build` on pushes and PRs targeting `master`
- Equivalent behavior to the old Travis config, now natively integrated with GitHub

## Test plan
- [ ] Verify the Actions workflow runs and passes on merge